### PR TITLE
fix: return hyper->value dict from hyperparam search

### DIFF
--- a/rlevaluation/hypers/api.py
+++ b/rlevaluation/hypers/api.py
@@ -57,13 +57,17 @@ def select_best_hypers(
 
     rng = np.random.default_rng(0)
     out = bootstrap_hyper_selection(rng, score_per_seed, statistic.value, prefer.value, threshold)
+    config = {
+        col: df[col][out.best_idx] for col in cols
+    }
 
     return HyperSelectionResult(
-        best_configuration=df.row(out.best_idx),
+        best_configuration=config,
         best_score=out.best_score,
 
         uncertainty_set_configurations=[
-            df.row(idx) for idx in out.uncertainty_set_idxs
+            {col: df[col][int(idx)] for col in cols}
+            for idx in out.uncertainty_set_idxs
         ],
         uncertainty_set_probs=out.uncertainty_set_probs,
         sample_stat=out.sample_stat,
@@ -72,10 +76,10 @@ def select_best_hypers(
     )
 
 class HyperSelectionResult(NamedTuple):
-    best_configuration: tuple[Any, ...]
+    best_configuration: dict[str, Any]
     best_score: float
 
-    uncertainty_set_configurations: list[tuple[Any, ...]]
+    uncertainty_set_configurations: list[dict[str, Any]]
     uncertainty_set_probs: np.ndarray
     sample_stat: float
     ci: tuple[float, float]

--- a/rlevaluation/hypers/reporting.py
+++ b/rlevaluation/hypers/reporting.py
@@ -35,14 +35,14 @@ def pretty_print_hyper_selection_result(result: HyperSelectionResult, d: DataDef
     if len(result.uncertainty_set_probs) > 1:
         out += 'Possible best configurations:\n'
         out += '-----------------------------\n'
-        for i, hyper in enumerate(cols):
-            hyper_val = result.uncertainty_set_configurations[0][i]
+        for hyper in cols:
+            hyper_val = result.uncertainty_set_configurations[0][hyper]
             if isinstance(hyper_val, float) and np.isnan(hyper_val): continue
             ws = 4 + col_len - len(hyper)
             out += f'{hyper}:' + ' ' * ws
 
             for config in result.uncertainty_set_configurations:
-                out += f'{config[i]}  '
+                out += f'{config[hyper]}  '
 
             out += '\n'
 

--- a/tests/test_hypers.py
+++ b/tests/test_hypers.py
@@ -13,4 +13,4 @@ def test_select_best_hypers():
     d = data_definition(hyper_cols=['alpha'])
 
     best = select_best_hypers(test_data, 'result', Preference.high, data_definition=d)
-    assert best.best_configuration[0] == 0.01
+    assert best.best_configuration['alpha'] == 0.01


### PR DESCRIPTION
We previously used dictionaries to communicate the best hyperparameter configurations found by the search which is quite a bit less brittle than a tuple with magic ordering. Also a few other methods (e.g. extract_learning_curves) expect that hypers are a dict instead of a tuple, so it's best to have internal consistency here.